### PR TITLE
Separate environments with ClusterSelectors

### DIFF
--- a/foo-corp/clusterregistry/dev-cluster.yaml
+++ b/foo-corp/clusterregistry/dev-cluster.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: clusterregistry.k8s.io/v1alpha1
+metadata:
+  name: dev-cluster
+  labels:
+    environment: dev

--- a/foo-corp/clusterregistry/dev-clusterselector.yaml
+++ b/foo-corp/clusterregistry/dev-clusterselector.yaml
@@ -1,7 +1,7 @@
 kind: ClusterSelector
 apiVersion: configmanagement.gke.io/v1
 metadata:
-  name: dev-clusterselector
+  name: dev
 spec:
   selector:
     matchLabels:

--- a/foo-corp/clusterregistry/dev-clusterselector.yaml
+++ b/foo-corp/clusterregistry/dev-clusterselector.yaml
@@ -1,0 +1,9 @@
+kind: ClusterSelector
+apiVersion: configmanagement.gke.io/v1
+metadata:
+  name: dev-clusterselector
+spec:
+  selector:
+    matchLabels:
+      environment: dev
+

--- a/foo-corp/clusterregistry/prod-cluster.yaml
+++ b/foo-corp/clusterregistry/prod-cluster.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: clusterregistry.k8s.io/v1alpha1
+metadata:
+  name: prod-cluster
+  labels:
+    environment: prod

--- a/foo-corp/clusterregistry/prod-clusterselector.yaml
+++ b/foo-corp/clusterregistry/prod-clusterselector.yaml
@@ -1,7 +1,7 @@
 kind: ClusterSelector
 apiVersion: configmanagement.gke.io/v1
 metadata:
-  name: prod-clusterselector
+  name: prod
 spec:
   selector:
     matchLabels:

--- a/foo-corp/clusterregistry/prod-clusterselector.yaml
+++ b/foo-corp/clusterregistry/prod-clusterselector.yaml
@@ -1,0 +1,9 @@
+kind: ClusterSelector
+apiVersion: configmanagement.gke.io/v1
+metadata:
+  name: prod-clusterselector
+spec:
+  selector:
+    matchLabels:
+      environment: prod
+

--- a/foo-corp/clusterregistry/staging-cluster.yaml
+++ b/foo-corp/clusterregistry/staging-cluster.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: clusterregistry.k8s.io/v1alpha1
+metadata:
+  name: staging-cluster
+  labels:
+    environment: staging

--- a/foo-corp/clusterregistry/staging-clusterselector.yaml
+++ b/foo-corp/clusterregistry/staging-clusterselector.yaml
@@ -1,7 +1,7 @@
 kind: ClusterSelector
 apiVersion: configmanagement.gke.io/v1
 metadata:
-  name: staging-clusterselector
+  name: staging
 spec:
   selector:
     matchLabels:

--- a/foo-corp/clusterregistry/staging-clusterselector.yaml
+++ b/foo-corp/clusterregistry/staging-clusterselector.yaml
@@ -1,0 +1,9 @@
+kind: ClusterSelector
+apiVersion: configmanagement.gke.io/v1
+metadata:
+  name: staging-clusterselector
+spec:
+  selector:
+    matchLabels:
+      environment: staging
+

--- a/foo-corp/namespaces/online/shipping-app-backend/shipping-dev/namespace.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/shipping-dev/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: shipping-dev
+  annotations:
+    configmanagement.gke.io/cluster-selector: dev

--- a/foo-corp/namespaces/online/shipping-app-backend/shipping-prod/namespace.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/shipping-prod/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     env: prod
   annotations:
     audit: "true"
+    configmanagement.gke.io/cluster-selector: prod

--- a/foo-corp/namespaces/online/shipping-app-backend/shipping-staging/namespace.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/shipping-staging/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: shipping-staging
+  annotations:
+    configmanagement.gke.io/cluster-selector: staging


### PR DESCRIPTION
Create ClusterSelectors for dev/staging/prod.

This ensures dev-, staging-, and prod-specific objects are only instantiated in the relevant clusters.